### PR TITLE
Adds helper method to download worcloud for a document

### DIFF
--- a/pypln/api.py
+++ b/pypln/api.py
@@ -19,6 +19,7 @@
 
 '''Implements a Python-layer to access PyPLN's API through HTTP'''
 
+import base64
 import urllib
 import urlparse
 
@@ -95,6 +96,11 @@ class Document(object):
             raise RuntimeError("Getting property {} failed with status "
                                "{}. The response was: '{}'".format(prop,
                                    response.status_code, response.text))
+
+    def download_wordcloud(self, filename):
+        encoded_png = self.get_property('wordcloud')
+        with open(filename, 'w') as fp:
+            fp.write(base64.b64decode(encoded_png))
 
     @property
     def properties(self):

--- a/tests/test_pypln.py
+++ b/tests/test_pypln.py
@@ -17,9 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with PyPLN.  If not, see <http://www.gnu.org/licenses/>.
 
+import base64
 import unittest
 
-from mock import call, patch, Mock
+from mock import call, patch, Mock, mock_open
 
 import requests
 
@@ -552,3 +553,23 @@ class DocumentTest(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             document.get_property('text')
+
+    @patch("requests.Session.get")
+    def test_download_wordcloud(self, mocked_get):
+        png = "This is not really a png.\n"
+        encoded_png = base64.b64encode(png)
+
+        mocked_get.return_value.status_code = 200
+        mocked_get.return_value.json.return_value = {'value': encoded_png}
+
+        document = Document(session=self.session, **self.example_json)
+
+        m = mock_open()
+        with patch('__builtin__.open', m, create=True):
+            document.download_wordcloud('test.png')
+
+        m.assert_called_once_with('test.png', 'w')
+        handle = m()
+        handle.write.assert_called_once_with(png)
+        mocked_get.assert_called_with(self.example_json['properties'] +
+                'wordcloud')


### PR DESCRIPTION
This is a little helper method to download the wordcloud for a document. It would be great if any of you @turicas, @fccoelho or @rsouza could review and merge.
