### PR TITLE
WIP: feature/api improvements

### DIFF
--- a/pypln/api.py
+++ b/pypln/api.py
@@ -128,6 +128,22 @@ class Document(object):
                                "{}. The response was: '{}'".format(response.status_code,
                                 response.text))
 
+    def delete(self):
+        '''
+        Deletes the document. Be very careful, since this operation is
+        irreversible.
+
+        Returns True if the Document was successfully deleted, raises
+        RuntimeError otherwise.
+        '''
+        result = self.session.delete(self.url)
+        if result.status_code == 204:
+            return True
+        else:
+            raise RuntimeError("Document deletion failed with status "
+                               "{}. The response was: '{}'".format(result.status_code,
+                                result.text))
+
 
 class Corpus(object):
     '''Class that represents a Corpus in PyPLN'''

--- a/pypln/api.py
+++ b/pypln/api.py
@@ -156,6 +156,9 @@ class Corpus(object):
         '''
         self.session = session
         for key, value in kwargs.items():
+            if key == 'documents':
+                value = map(lambda d: Document(session=self.session, **d),
+                        value)
             setattr(self, key, value)
 
         splited_url = urlsplit(self.url)

--- a/pypln/api.py
+++ b/pypln/api.py
@@ -209,6 +209,22 @@ class Corpus(object):
 
         return result, errors
 
+    def delete(self):
+        '''
+        Deletes the corpus. Be very careful, since this operation is
+        irreversible.
+
+        Returns True if the Corpus was successfully deleted, raises
+        RuntimeError otherwise.
+        '''
+        result = self.session.delete(self.url)
+        if result.status_code == 204:
+            return True
+        else:
+            raise RuntimeError("Corpus deletion failed with status "
+                               "{}. The response was: '{}'".format(result.status_code,
+                                result.text))
+
 class PyPLN(object):
     """
     Class to connect to PyPLN's API and execute some actions

--- a/tests/test_pypln.py
+++ b/tests/test_pypln.py
@@ -379,6 +379,27 @@ class CorpusTest(unittest.TestCase):
         self.assertEqual(result[1][0][0], expected[1][0][0])
         self.assertIsInstance(expected[1][0][1], RuntimeError)
 
+    @patch("requests.Session.delete")
+    def test_delete_corpus(self, mocked_delete):
+        mocked_delete.return_value.status_code = 204
+
+        corpus = Corpus(session=self.session, **self.example_json)
+        result = corpus.delete()
+
+        mocked_delete.assert_called_with(self.example_json['url'])
+        self.assertTrue(result)
+
+    @patch("requests.Session.delete")
+    def test_corpus_deletion_fails(self, mocked_delete):
+        mocked_delete.return_value.status_code = 403
+
+        session = requests.Session()
+        session.auth = ('wrong_user', 'my_precious')
+        corpus = Corpus(session=session, **self.example_json)
+
+        with self.assertRaises(RuntimeError):
+            corpus.delete()
+
 
 class DocumentTest(unittest.TestCase):
 

--- a/tests/test_pypln.py
+++ b/tests/test_pypln.py
@@ -400,6 +400,51 @@ class CorpusTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             corpus.delete()
 
+    def test_get_all_documents(self):
+        example_document_2 = {
+             'owner': 'user',
+             'corpus': 'http://pypln.example.com/corpora/42/',
+             'size': 43,
+             'properties': 'http://pypln.example.com/documents/124/properties',
+             'url': 'http://pypln.example.com/documents/124/',
+             'blob': '/test_2.txt',
+             'uploaded_at': '2013-10-25T17:00:01.000Z',
+         }
+
+        expected_documents = [
+            Document(session=self.session, **self.example_document),
+            Document(session=self.session, **example_document_2)
+        ]
+
+        self.example_json['documents'] = [self.example_document,
+                example_document_2]
+
+        corpus = Corpus(session=self.session, **self.example_json)
+
+        for document in corpus.documents:
+            self.assertIsInstance(document, Document)
+
+        retrieved_document_1 = corpus.documents[0]
+        retrieved_document_2 = corpus.documents[1]
+
+        for key, value in self.example_document.items():
+            # `properties` is a method on `Document` class, so replacing with
+            # `properties_url` to test each key/value
+            if key == 'properties':
+                key = 'properties_url'
+            self.assertEqual(value, getattr(retrieved_document_1, key))
+
+        for key, value in example_document_2.items():
+            # `properties` is a method on `Document` class, so replacing with
+            # `properties_url` to test each key/value
+            if key == 'properties':
+                key = 'properties_url'
+            self.assertEqual(value, getattr(retrieved_document_2, key))
+
+        # Document objects should link `session` object from the Corpus
+        self.assertIs(retrieved_document_1.session, corpus.session)
+        self.assertIs(retrieved_document_2.session, corpus.session)
+
 
 class DocumentTest(unittest.TestCase):
 

--- a/tests/test_pypln.py
+++ b/tests/test_pypln.py
@@ -603,3 +603,24 @@ class DocumentTest(unittest.TestCase):
         handle.write.assert_called_once_with(png.decode('ascii'))
         mocked_get.assert_called_with(self.example_json['properties'] +
                 'wordcloud')
+
+    @patch("requests.Session.delete")
+    def test_delete_document(self, mocked_delete):
+        mocked_delete.return_value.status_code = 204
+
+        document = Document(session=self.session, **self.example_json)
+        result = document.delete()
+
+        mocked_delete.assert_called_with(self.example_json['url'])
+        self.assertTrue(result)
+
+    @patch("requests.Session.delete")
+    def test_document_deletion_fails(self, mocked_delete):
+        mocked_delete.return_value.status_code = 403
+
+        session = requests.Session()
+        session.auth = ('wrong_user', 'my_precious')
+        document = Document(session=session, **self.example_json)
+
+        with self.assertRaises(RuntimeError):
+            document.delete()


### PR DESCRIPTION
This Pull Request is still a work in progress, so it should probably not be merged yet. I'm publishing it here so I can get reviews.

I've added methods to delete the objects (instead of having to call the `delete` method from `requests` with the entity URL). The biggest change, though, is returning `Document` objects in the when accessing the `documents` attribute of a `Corpus`. This change breaks backward compatibility, so we need to be sure we want that before we merge this (we also need to bump our major version before we publish to pypi). 

I'd like you all @rsouza , @fccoelho and @eduardostalinho to review this, please. Specially the `test_get_all_documents` test.
